### PR TITLE
Wip enhanced conditions filters

### DIFF
--- a/gene/src/paths.rs
+++ b/gene/src/paths.rs
@@ -5,7 +5,7 @@ use thiserror::Error;
 
 use crate::rules::matcher::{MatchParser, Rule};
 
-#[derive(Error, Debug, Clone)]
+#[derive(Error, Debug, Clone, PartialEq)]
 pub enum PathError {
     #[error("{0}")]
     Parse(#[from] Box<pest::error::Error<Rule>>),

--- a/gene/src/rules.rs
+++ b/gene/src/rules.rs
@@ -228,7 +228,7 @@ pub struct CompiledRule {
     pub(crate) actions: HashSet<String>,
 }
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum Error {
     #[error("rule={0} {1}")]
     Wrap(String, Box<Error>),

--- a/gene/src/rules.rs
+++ b/gene/src/rules.rs
@@ -151,9 +151,48 @@ impl Rule {
         self
     }
 
+    // build filter for events to include (positive values in
+    // `match-on` section)
+    fn build_include_events(
+        filters: &HashMap<String, HashSet<i64>>,
+    ) -> HashMap<String, HashSet<i64>> {
+        let mut inc = HashMap::new();
+        for (source, events) in filters {
+            let events = events
+                .iter()
+                .filter(|&&id| id >= 0)
+                .cloned()
+                .collect::<HashSet<i64>>();
+            if !events.is_empty() {
+                inc.insert(source.clone(), events);
+            }
+        }
+        inc
+    }
+
+    // build filter for events to exclude (negative values in
+    // `match-on` section)
+    fn build_exclude_events(
+        filters: &HashMap<String, HashSet<i64>>,
+    ) -> HashMap<String, HashSet<i64>> {
+        let mut excl = HashMap::new();
+        for (source, events) in filters {
+            let events = events
+                .iter()
+                .filter(|&&id| id < 0)
+                .map(|id| id.abs())
+                .collect::<HashSet<i64>>();
+            if !events.is_empty() {
+                excl.insert(source.clone(), events);
+            }
+        }
+        excl
+    }
+
     #[inline]
     pub fn compile_into(self) -> Result<CompiledRule, Error> {
         let name = self.name.clone();
+        let filters = self.match_on.and_then(|mo| mo.events).unwrap_or_default();
 
         // to wrap error with rule name
         || -> Result<CompiledRule, Error> {
@@ -162,7 +201,8 @@ impl Rule {
                 filter: self.params.and_then(|p| p.filter).unwrap_or_default(),
                 tags: HashSet::new(),
                 attack: HashSet::new(),
-                events: self.match_on.and_then(|mo| mo.events).unwrap_or_default(),
+                include_events: Self::build_include_events(&filters),
+                exclude_events: Self::build_exclude_events(&filters),
                 matches: HashMap::new(),
                 condition: match self.condition {
                     Some(cond) => {
@@ -221,7 +261,8 @@ pub struct CompiledRule {
     pub(crate) filter: bool,
     pub(crate) tags: HashSet<String>,
     pub(crate) attack: HashSet<String>,
-    pub(crate) events: HashMap<String, HashSet<i64>>,
+    pub(crate) include_events: HashMap<String, HashSet<i64>>,
+    pub(crate) exclude_events: HashMap<String, HashSet<i64>>,
     pub(crate) matches: HashMap<String, Match>,
     pub(crate) condition: condition::Condition,
     pub(crate) severity: u8,
@@ -271,17 +312,33 @@ impl CompiledRule {
 
     #[inline(always)]
     pub(crate) fn can_match_on(&self, src: &String, id: i64) -> bool {
-        if self.events.is_empty() {
+        // we have no filter at all
+        if self.include_events.is_empty() && self.exclude_events.is_empty() {
             return true;
         }
 
-        if let Some(set) = self.events.get(src) {
-            if set.is_empty() {
-                return true;
+        // explicit event excluding logic
+        let opt_exclude = self.exclude_events.get(src);
+        if let Some(exclude) = opt_exclude {
+            // we definitely want to exclude that event
+            if exclude.contains(&id) {
+                return false;
             }
-            return set.contains(&id);
         }
 
+        let opt_include = self.include_events.get(src);
+        // we include if we have no include filter for this source
+        // but we have an exclude filter (that didn't match)
+        if opt_include.is_none() && opt_exclude.is_some() {
+            return true;
+        }
+
+        // we return result of lookup in include filter if there is one
+        if let Some(include) = opt_include {
+            return include.contains(&id);
+        }
+
+        // default we cannot match on event
         false
     }
 
@@ -476,10 +533,6 @@ condition: $c
         let test = r#"
 ---
 name: test
-match-on:
-    events:
-        test: [42]
-condition:
 ..."#;
 
         let d: Rule = serde_yaml::from_str(test).unwrap();

--- a/gene/src/rules/condition.rs
+++ b/gene/src/rules/condition.rs
@@ -32,6 +32,14 @@ pub(crate) enum Op {
 #[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Expr {
     Variable(String),
+    AllOfThem,
+    AllOfVars(String),
+    AnyOfThem,
+    AnyOfVars(String),
+    NoneOfThem,
+    NoneOfVars(String),
+    NOfThem(usize),
+    NOfVars(usize, String),
     BinOp {
         lhs: Box<Expr>,
         op: Op,
@@ -81,6 +89,94 @@ impl Expr {
         event: &E,
     ) -> Result<bool, Error> {
         match self {
+            Expr::AllOfThem => {
+                for m in operands.values() {
+                    if !m.match_event(event)? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
+            Expr::AllOfVars(start) => {
+                for m in operands
+                    .iter()
+                    .filter(|(v, _)| v.starts_with(start))
+                    .map(|(_, m)| m)
+                {
+                    if !m.match_event(event)? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
+            Expr::NOfThem(n) => {
+                let mut c = 0;
+                for m in operands.values() {
+                    if m.match_event(event)? {
+                        c += 1;
+                        if c >= *n {
+                            return Ok(true);
+                        }
+                    }
+                }
+                Ok(c >= *n)
+            }
+            Expr::NOfVars(n, start) => {
+                let mut c = 0;
+                for m in operands
+                    .iter()
+                    .filter(|(v, _)| v.starts_with(start))
+                    .map(|(_, m)| m)
+                {
+                    if m.match_event(event)? {
+                        c += 1;
+                        if c >= *n {
+                            return Ok(true);
+                        }
+                    }
+                }
+                Ok(c >= *n)
+            }
+            Expr::AnyOfThem => {
+                for m in operands.values() {
+                    if m.match_event(event)? {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            }
+            Expr::AnyOfVars(start) => {
+                for m in operands
+                    .iter()
+                    .filter(|(v, _)| v.starts_with(start))
+                    .map(|(_, m)| m)
+                {
+                    if m.match_event(event)? {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            }
+            Expr::NoneOfThem => {
+                for m in operands.values() {
+                    if m.match_event(event)? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
+            Expr::NoneOfVars(start) => {
+                for m in operands
+                    .iter()
+                    .filter(|(v, _)| v.starts_with(start))
+                    .map(|(_, m)| m)
+                {
+                    if m.match_event(event)? {
+                        return Ok(false);
+                    }
+                }
+                Ok(true)
+            }
             Expr::Variable(var) => {
                 if let Some(m) = operands.get(var) {
                     return m.match_event(event).map_err(|e| e.into());
@@ -100,15 +196,58 @@ impl Expr {
 
     #[allow(dead_code)]
     // this function is used in test
-    fn compute(&self, operands: &HashMap<&str, bool>) -> bool {
+    fn compute(&self, operands: &HashMap<&str, bool>) -> Result<bool, Error> {
         match self {
-            Expr::Variable(var) => *(operands.get(var.as_str()).unwrap()),
+            Expr::AllOfThem => Ok(operands.iter().all(|(_, &b)| b)),
+            Expr::AllOfVars(start) => Ok(operands
+                .iter()
+                .filter(|(v, _)| v.starts_with(start))
+                .all(|(_, &b)| b)),
+            Expr::AnyOfThem => Ok(operands.iter().any(|(_, &b)| b)),
+            Expr::AnyOfVars(start) => Ok(operands
+                .iter()
+                .filter(|(v, _)| v.starts_with(start))
+                .any(|(_, &b)| b)),
+            Expr::NoneOfThem => Ok(!operands.iter().any(|(_, &b)| b)),
+            Expr::NoneOfVars(start) => Ok(!operands
+                .iter()
+                .filter(|(v, _)| v.starts_with(start))
+                .any(|(_, &b)| b)),
+            Expr::NOfThem(x) => {
+                if operands.len() < *x {
+                    return Ok(false);
+                }
+                for (c, _) in operands.iter().filter(|(_, &b)| b).enumerate() {
+                    // +1 because we start iterating at 0 ><
+                    if c + 1 >= *x {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            }
+            Expr::NOfVars(x, start) => {
+                if operands.len() < *x {
+                    return Ok(false);
+                }
+                for (c, _) in operands
+                    .iter()
+                    .filter(|(v, &b)| b && v.starts_with(start))
+                    .enumerate()
+                {
+                    // +1 because we start iterating at 0 ><
+                    if c + 1 >= *x {
+                        return Ok(true);
+                    }
+                }
+                Ok(false)
+            }
+            Expr::Variable(var) => Ok(*(operands.get(var.as_str()).unwrap())),
             Expr::BinOp { lhs, op, rhs } => match op {
-                Op::And => lhs.compute(operands) && rhs.compute(operands),
-                Op::Or => lhs.compute(operands) || rhs.compute(operands),
+                Op::And => Ok(lhs.compute(operands)? && rhs.compute(operands)?),
+                Op::Or => Ok(lhs.compute(operands)? || rhs.compute(operands)?),
             },
-            Expr::Negate(expr) => !expr.compute(operands),
-            Expr::None => true,
+            Expr::Negate(expr) => Ok(!expr.compute(operands)?),
+            Expr::None => Ok(true),
         }
     }
 }
@@ -116,8 +255,50 @@ impl Expr {
 fn parse_expr(pairs: Pairs<Rule>) -> Expr {
     PRATT_PARSER
         .map_primary(|primary| match primary.as_rule() {
-            Rule::ident => Expr::Variable(primary.as_str().into()),
-            Rule::expr => parse_expr(primary.into_inner()),
+            Rule::var => Expr::Variable(primary.as_str().into()),
+            Rule::all_of_them => Expr::AllOfThem,
+            Rule::all_of_vars => {
+                Expr::AllOfVars(primary.as_str().rsplit_once(' ').unwrap().1.into())
+            }
+            Rule::none_of_them => Expr::NoneOfThem,
+            Rule::none_of_vars => {
+                Expr::NoneOfVars(primary.as_str().rsplit_once(' ').unwrap().1.into())
+            }
+            Rule::any_of_them => Expr::AnyOfThem,
+            Rule::any_of_vars => {
+                Expr::AnyOfVars(primary.as_str().rsplit_once(' ').unwrap().1.into())
+            }
+            Rule::n_of_them => {
+                // this should not panic in anyways as it is validated by pest
+                let n = // this should not panic in anyways as it is validated by pest
+                primary
+                    .as_str()
+                    .split_once(' ')
+                    .unwrap()
+                    .0
+                    .parse::<usize>()
+                    .unwrap();
+                if n == 0 {
+                    // equivalent to none of them
+                    return Expr::NoneOfThem;
+                }
+                Expr::NOfThem(n)
+            }
+            Rule::n_of_vars => {
+                let n = primary
+                    .as_str()
+                    .split_once(' ')
+                    .unwrap()
+                    .0
+                    .parse::<usize>()
+                    .unwrap();
+                let vars = primary.as_str().rsplit_once(' ').unwrap().1.into();
+                if n == 0 {
+                    return Expr::NoneOfVars(vars);
+                }
+                Expr::NOfVars(n, vars)
+            }
+            Rule::expr | Rule::ident | Rule::group => parse_expr(primary.into_inner()),
             rule => unreachable!("Expr::parse expected atom, found {:?}", rule),
         })
         .map_infix(|lhs, op, rhs| {
@@ -201,10 +382,151 @@ mod tests {
             "$a and $b",
             "$a and ($b or ($c and $d))",
             "($a or $b) and $c",
+            "any of them",
+            "any of $app_",
+            "all of them",
+            "all of $app_",
+            "none of them",
+            "none of $app_",
+            "42 of them",
+            "42 of $app_",
         ];
 
         valid.iter().for_each(|ident| {
-            Expr::from_str(ident).unwrap();
+            println!("{:?}", Expr::from_str(ident).unwrap());
         });
+
+        // special cases
+        assert_eq!("0 of them".parse::<Expr>().unwrap(), Expr::NoneOfThem);
+
+        assert_eq!(
+            "0 of $app".parse::<Expr>().unwrap(),
+            Expr::NoneOfVars("$app".into())
+        );
+    }
+
+    #[test]
+    fn test_all_of_them() {
+        let expr = Expr::from_str("all of them").unwrap();
+        let mut operands = {
+            let mut m = HashMap::new();
+            m.insert("$a", true);
+            m.insert("$b", true);
+            m
+        };
+
+        assert_eq!(expr.compute(&operands), Ok(true));
+        operands.insert("$c", false);
+        assert_eq!(expr.compute(&operands), Ok(false));
+    }
+
+    #[test]
+    fn test_all_of_vars() {
+        let expr = Expr::from_str("all of $app").unwrap();
+        let mut operands = {
+            let mut m = HashMap::new();
+            m.insert("$app1", true);
+            m.insert("$app2", true);
+            m.insert("$b", false);
+            m
+        };
+
+        assert_eq!(expr.compute(&operands), Ok(true));
+        operands.insert("$app3", false);
+        assert_eq!(expr.compute(&operands), Ok(false));
+    }
+
+    #[test]
+    fn test_any_of_them() {
+        let expr = Expr::from_str("any of them").unwrap();
+        let mut operands = {
+            let mut m = HashMap::new();
+            m.insert("$a", true);
+            m.insert("$b", false);
+            m
+        };
+
+        assert_eq!(expr.compute(&operands), Ok(true));
+        operands.entry("$a").and_modify(|b| *b = false);
+        assert_eq!(expr.compute(&operands), Ok(false));
+    }
+
+    #[test]
+    fn test_any_of_vars() {
+        let expr = Expr::from_str("any of $app").unwrap();
+        let mut operands = {
+            let mut m = HashMap::new();
+            m.insert("$app1", true);
+            m.insert("$app2", false);
+            m.insert("$b", true);
+            m
+        };
+
+        assert_eq!(expr.compute(&operands), Ok(true));
+        operands.entry("$app1").and_modify(|b| *b = false);
+        assert_eq!(expr.compute(&operands), Ok(false));
+    }
+
+    #[test]
+    fn test_none_of_them() {
+        let expr = Expr::from_str("none of them").unwrap();
+        let mut operands = {
+            let mut m = HashMap::new();
+            m.insert("$a", true);
+            m.insert("$b", false);
+            m
+        };
+
+        assert_eq!(expr.compute(&operands), Ok(false));
+        operands.entry("$a").and_modify(|b| *b = false);
+        assert_eq!(expr.compute(&operands), Ok(true));
+    }
+
+    #[test]
+    fn test_none_of_vars() {
+        let expr = Expr::from_str("none of $app").unwrap();
+        let mut operands = {
+            let mut m = HashMap::new();
+            m.insert("$app1", true);
+            m.insert("$app2", true);
+            m.insert("$b", false);
+            m
+        };
+
+        assert_eq!(expr.compute(&operands), Ok(false));
+        operands.entry("$app1").and_modify(|b| *b = false);
+        operands.entry("$app2").and_modify(|b| *b = false);
+        assert_eq!(expr.compute(&operands), Ok(true));
+    }
+
+    #[test]
+    fn test_x_of_them() {
+        let expr = Expr::from_str("1 of them").unwrap();
+        let mut operands = {
+            let mut m = HashMap::new();
+            m.insert("$a", true);
+            m.insert("$b", false);
+            m
+        };
+
+        assert_eq!(expr.compute(&operands), Ok(true));
+        operands.entry("$a").and_modify(|b| *b = false);
+        assert_eq!(expr.compute(&operands), Ok(false));
+    }
+
+    #[test]
+    fn test_x_of_vars() {
+        let expr = Expr::from_str("1 of $app").unwrap();
+        let mut operands = {
+            let mut m = HashMap::new();
+            m.insert("$app1", true);
+            m.insert("$app2", false);
+            m.insert("$b", true);
+            m
+        };
+
+        assert_eq!(expr.compute(&operands), Ok(true));
+        operands.entry("$app1").and_modify(|b| *b = false);
+        assert_eq!(expr.compute(&operands), Ok(false));
     }
 }

--- a/gene/src/rules/condition.rs
+++ b/gene/src/rules/condition.rs
@@ -23,13 +23,13 @@ lazy_static::lazy_static! {
     };
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Op {
     And,
     Or,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub(crate) enum Expr {
     Variable(String),
     BinOp {
@@ -47,7 +47,7 @@ impl Default for Expr {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum Error {
     #[error("unknown operand {0}")]
     UnknowOperand(String),

--- a/gene/src/rules/condition/condition_test.rs
+++ b/gene/src/rules/condition/condition_test.rs
@@ -11,7 +11,7 @@ mod test {
     fn test_condition_computation() {
         TEST_CONDITIONS.iter().for_each(|(condition, result)| {
             let cond = Expr::from_str(condition).unwrap();
-            assert_eq!(cond.compute(&OPERANDS), *result)
+            assert_eq!(cond.compute(&OPERANDS).unwrap(), *result)
         });
     }
 }

--- a/gene/src/rules/grammars/condition.pest
+++ b/gene/src/rules/grammars/condition.pest
@@ -1,4 +1,22 @@
-ident = @{ "$" ~ (ASCII_ALPHANUMERIC | "_")+ }
+ident = _{ var | group }
+var   = @{ "$" ~ (ASCII_ALPHANUMERIC | "_")+ }
+
+// meta expressions
+group   =  { n_of_them | n_of_vars | all_of_them | all_of_vars | any_of_them | any_of_vars | none_of_them | none_of_vars }
+of_them = _{ "of" ~ "them" }
+of_vars = _{ "of" ~ var }
+// x_of
+n_of_them = { ASCII_DIGIT+ ~ of_them }
+n_of_vars = { ASCII_DIGIT+ ~ of_vars }
+// all_of
+all_of_them = { "all" ~ of_them }
+all_of_vars = { "all" ~ of_vars }
+// any_of
+any_of_them = { "any" ~ of_them }
+any_of_vars = { "any" ~ of_vars }
+// none_of
+none_of_them = { "none" ~ of_them }
+none_of_vars = { "none" ~ of_vars }
 
 negate =  { ("!" | "not") }
 op     = _{ or | and }

--- a/gene/src/rules/matcher.rs
+++ b/gene/src/rules/matcher.rs
@@ -82,7 +82,7 @@ impl MatchValue {
     }
 }
 
-#[derive(Error, Debug)]
+#[derive(Error, Debug, PartialEq)]
 pub enum Error {
     #[error("field={0} not found")]
     FieldNotFound(String),

--- a/gene/src/values.rs
+++ b/gene/src/values.rs
@@ -7,7 +7,7 @@ use std::{
 
 use thiserror::Error;
 
-#[derive(Debug, Error)]
+#[derive(Debug, Error, PartialEq)]
 pub enum NumberError {
     #[error("")]
     InvalidConvertion,

--- a/gene/tests/data/compiled.gen
+++ b/gene/tests/data/compiled.gen
@@ -873,7 +873,7 @@ meta:
 name: HeurLongDomain
 params:
   filter: false
-  disable: false
+  disable: true
 match-on:
   events:
     Microsoft-Windows-DNS-Client/Operational: []
@@ -1785,7 +1785,7 @@ actions: null
 name: PSC#Win32API
 params:
   filter: false
-  disable: false
+  disable: true
 match-on:
   events:
     Microsoft-Windows-PowerShell/Operational: []
@@ -2206,7 +2206,7 @@ meta:
 name: SuspWriteAccess
 params:
   filter: false
-  disable: false
+  disable: true
 match-on:
   events:
     Microsoft-Windows-Sysmon/Operational:
@@ -2691,7 +2691,7 @@ meta:
 name: UnknownServices
 params:
   filter: false
-  disable: false
+  disable: true
 match-on:
   events:
     Microsoft-Windows-Sysmon/Operational:

--- a/gene/tests/rust_events_test.rs
+++ b/gene/tests/rust_events_test.rs
@@ -76,7 +76,7 @@ fn test_fast() {
         let scan_dur = time_it(|| {
             for _ in 0..run_count {
                 for e in events.iter() {
-                    if let Some(sr) = engine.scan(e).ok().and_then(|v| v) {
+                    if let Some(sr) = engine.scan(e).unwrap_or_default() {
                         if sr.is_detection() {
                             positives += 1
                         }


### PR DESCRIPTION
Add features:
- new conditions: `all of them` `all of $var_prefix` `n of them` `n of $var_prefix` `none of them` `none of $var_prefix`
- allow filter out event by ids in `matcth-on` section

