### PR TITLE
add: Engine::compiled_rules API

### DIFF
--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -341,7 +341,6 @@ impl FieldGetterDerive {
 ///
 /// `#[getter(skip)]` skip the field from being implemented. It is important to know
 /// that any access to a skipped field will return [None]
-
 #[proc_macro_derive(FieldGetter, attributes(getter))]
 pub fn field_getter_derive(item: TokenStream) -> TokenStream {
     let input = parse_macro_input!(item as DeriveInput);

--- a/gene/benches/engine_benchmark.rs
+++ b/gene/benches/engine_benchmark.rs
@@ -77,7 +77,7 @@ fn bench_rust_events(c: &mut Criterion) {
 
         let mut engine = Engine::try_from(compiler.clone()).unwrap();
 
-        group.bench_function(&format!("scan-with-{}-rules", engine.rules_count()), |b| {
+        group.bench_function(format!("scan-with-{}-rules", engine.rules_count()), |b| {
             b.iter(|| {
                 for e in events.iter() {
                     let _ = engine.scan(e);

--- a/gene/src/engine.rs
+++ b/gene/src/engine.rs
@@ -280,6 +280,11 @@ impl Engine {
             .to_vec()
     }
 
+    /// Returns the `Vec` of [CompiledRule] currently loaded in the engine
+    pub fn compiled_rules(&self) -> &Vec<CompiledRule> {
+        &self.rules
+    }
+
     /// returns the number of rules loaded in the engine
     #[inline(always)]
     pub fn rules_count(&self) -> usize {
@@ -777,6 +782,42 @@ condition: all of them
                 .unwrap()
                 .len(),
             2
+        );
+    }
+
+    #[test]
+    fn test_compiled_rules() {
+        let mut c = Compiler::new();
+        c.load_rules_from_str(
+            r#"
+name: dep.rule
+type: dependency
+
+---
+
+name: main
+type: filter
+
+---
+
+name: multi.deps
+type: detection
+"#,
+        )
+        .unwrap();
+
+        let e = Engine::try_from(c).unwrap();
+
+        assert_eq!(
+            e.compiled_rules().iter().filter(|c| c.is_filter()).count(),
+            1
+        );
+        assert_eq!(
+            e.compiled_rules()
+                .iter()
+                .filter(|c| c.is_detection())
+                .count(),
+            1
         );
     }
 }


### PR DESCRIPTION
gives a read only access to the compiled rules loaded in the Engine