### PR TITLE
feat: filter in scan result

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ members = ["gene", "derive"]
 
 [workspace.package]
 version = "0.4.3"
-rust-version = "1.65.0"
+rust-version = "1.83.0"
 authors = ["Quentin JEROME"]
 edition = "2021"
 license = "GPL-3.0"

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -166,9 +166,9 @@ impl EventDerive {
     }
 }
 
-/// Derives [Event](/gene/trait.Event.html) trait. It is required to also implement [FieldGetter](/gene/trait.FieldGetter.html).
+/// Derives [`Event`](/gene/trait.Event.html) trait. It is required to also implement [`FieldGetter`](/gene/trait.FieldGetter.html).
 ///
-/// **NB:** `FieldGetter` can be derived with [FieldGetter] derive macro
+/// **NB:** `FieldGetter` can be derived with [`FieldGetter`] derive macro
 ///
 /// # Structure Attributes
 ///
@@ -328,7 +328,7 @@ impl FieldGetterDerive {
     }
 }
 
-/// Derives [FieldGetter](/gene/trait.FieldGetter.html) trait
+/// Derives [`FieldGetter`](/gene/trait.FieldGetter.html) trait
 ///
 /// # Structure Attributes
 ///

--- a/gene/src/compiler.rs
+++ b/gene/src/compiler.rs
@@ -58,7 +58,7 @@ impl Compiler {
         self.load_templates_from_reader(c)
     }
 
-    /// Loads a set of string [Templates] into the compiler so that it
+    /// Loads a set of string [`Templates`] into the compiler so that it
     /// can replace the appropriate strings into the rules before compiling them
     pub fn load_templates(&mut self, t: Templates) -> Result<(), Error> {
         self.templates.extend(&t)?;
@@ -103,7 +103,7 @@ impl Compiler {
         Ok(())
     }
 
-    /// Compile all the [Rule] loaded via [Compiler::load] which
+    /// Compile all the [`Rule`] loaded via [Compiler::load] which
     /// have not been compiled yet.
     #[inline]
     pub fn compile(&mut self) -> Result<(), Error> {

--- a/gene/src/event.rs
+++ b/gene/src/event.rs
@@ -14,7 +14,7 @@ pub trait Event: FieldGetter {
 }
 
 /// Trait representing a structure we can fetch field values
-/// from a [XPath]
+/// from a [`XPath`]
 pub trait FieldGetter {
     #[inline]
     fn get_from_path(&self, path: &XPath) -> Option<FieldValue> {

--- a/gene/src/paths.rs
+++ b/gene/src/paths.rs
@@ -12,7 +12,7 @@ pub enum PathError {
 }
 
 /// Cross Path allowing to recursively retrieve a [FieldValue](crate::FieldValue)
-/// from a structure implementing [FieldGetter](crate::FieldGetter).
+/// from a structure implementing [`FieldGetter`](crate::FieldGetter).
 ///
 /// # Example:
 ///

--- a/gene/src/rules.rs
+++ b/gene/src/rules.rs
@@ -5,6 +5,7 @@ use lazy_static::lazy_static;
 use regex::Regex;
 use serde::{de, Deserialize, Serialize};
 use std::{
+    borrow::Cow,
     collections::{HashMap, HashSet},
     io,
     str::FromStr,
@@ -57,7 +58,7 @@ mod attack {
     }
 }
 
-/// Represents the type of [Rule]
+/// Represents the type of [`Rule`]
 #[derive(Debug, Clone, Copy)]
 pub enum Type {
     /// Use it to encode detection information.
@@ -170,7 +171,7 @@ pub struct MatchOn {
     pub events: Option<HashMap<String, HashSet<i64>>>,
 }
 
-/// Structure defining rule loadable in the [Engine](crate::Engine)
+/// Structure defining rule loadable in the [`Engine`](crate::Engine)
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct Rule {
@@ -399,7 +400,7 @@ impl CompiledRule {
     pub(crate) fn match_event_with_states<E: Event>(
         &self,
         event: &E,
-        rules_states: &HashMap<String, bool>,
+        rules_states: &HashMap<Cow<'_, str>, bool>,
     ) -> Result<bool, Error> {
         self.condition
             .compute_for_event(event, &self.matches, rules_states)

--- a/gene/src/rules/condition.rs
+++ b/gene/src/rules/condition.rs
@@ -1,7 +1,7 @@
 use super::matcher::{self, Match};
 use crate::Event;
 use pest::{iterators::Pairs, pratt_parser::PrattParser, Parser};
-use std::{collections::HashMap, hash::Hash, str::FromStr};
+use std::{borrow::Cow, collections::HashMap, hash::Hash, str::FromStr};
 use thiserror::Error;
 
 #[derive(pest_derive::Parser)]
@@ -87,7 +87,7 @@ impl Expr {
         &self,
         event: &E,
         operands: &HashMap<String, Match>,
-        rule_states: &HashMap<String, bool>,
+        rule_states: &HashMap<Cow<'_, str>, bool>,
     ) -> Result<bool, Error> {
         match self {
             Expr::AllOfThem => {
@@ -344,7 +344,7 @@ impl Condition {
         &self,
         event: &E,
         operands: &HashMap<String, Match>,
-        rules_states: &HashMap<String, bool>,
+        rules_states: &HashMap<Cow<'_, str>, bool>,
     ) -> Result<bool, Error> {
         self.expr.compute_for_event(event, operands, rules_states)
     }

--- a/gene/src/rules/matcher.rs
+++ b/gene/src/rules/matcher.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, str::FromStr};
+use std::{borrow::Cow, collections::HashMap, str::FromStr};
 
 use pest::{iterators::Pairs, Parser};
 use pest_derive::Parser;
@@ -184,7 +184,7 @@ impl Match {
     pub(crate) fn match_event<E: Event>(
         &self,
         event: &E,
-        rule_state: &HashMap<String, bool>,
+        rule_state: &HashMap<Cow<'_, str>, bool>,
     ) -> Result<bool, Error> {
         match self {
             Self::Direct(m) => m.match_event(event),
@@ -449,9 +449,9 @@ impl RuleMatch {
     }
 
     #[inline]
-    pub(crate) fn match_event(&self, states: &HashMap<String, bool>) -> Result<bool, Error> {
+    pub(crate) fn match_event(&self, states: &HashMap<Cow<'_, str>, bool>) -> Result<bool, Error> {
         states
-            .get(&self.0)
+            .get(&Cow::from(&self.0))
             .copied()
             .ok_or(Error::rule_not_found(&self.0))
     }

--- a/gene/src/template.rs
+++ b/gene/src/template.rs
@@ -66,7 +66,7 @@ impl Templates {
         Self::default()
     }
 
-    /// Inserts a new string template. Under the `matches` section of a [Rule]
+    /// Inserts a new string template. Under the `matches` section of a [`Rule`]
     /// any occurrence of `{{name}}` (`name` being the template name) will be
     /// replaced by the `template`.
     #[inline]
@@ -87,7 +87,7 @@ impl Templates {
         Ok(())
     }
 
-    /// Replaces templates in the given [Rule]
+    /// Replaces templates in the given [`Rule`]
     pub fn replace(&self, r: &mut Rule) {
         if let Some(matches) = r.matches.as_mut() {
             for op in matches.keys().cloned().collect::<Vec<_>>() {


### PR DESCRIPTION
This PR separates filter from detection information in the ScanResult structure.
As a consequence of this new design we now have information about the matching filters in the Filter structure. It is useful to debug filter or simply to display which filter rule matched. Filter structure have its own tags member allowing to include tag information in filtering rules to bring context to the filter or group filters by family.