### PR TITLE
perf: increase scan throughput

### DIFF
--- a/gene/src/rules.rs
+++ b/gene/src/rules.rs
@@ -389,7 +389,10 @@ impl CompiledRule {
     // keep this function not to break tests
     #[allow(dead_code)]
     #[inline(always)]
-    fn match_event<E: Event>(&self, event: &E) -> Result<bool, Error> {
+    fn match_event<E>(&self, event: &E) -> Result<bool, Error>
+    where
+        E: for<'e> Event<'e>,
+    {
         self.condition
             .compute_for_event(event, &self.matches, &HashMap::new())
             .map_err(|e| Box::new(e).into())
@@ -397,11 +400,14 @@ impl CompiledRule {
     }
 
     #[inline(always)]
-    pub(crate) fn match_event_with_states<E: Event>(
+    pub(crate) fn match_event_with_states<E>(
         &self,
         event: &E,
         rules_states: &HashMap<Cow<'_, str>, bool>,
-    ) -> Result<bool, Error> {
+    ) -> Result<bool, Error>
+    where
+        E: for<'e> Event<'e>,
+    {
         self.condition
             .compute_for_event(event, &self.matches, rules_states)
             .map_err(|e| Box::new(e).into())
@@ -497,7 +503,7 @@ mod test {
         ($name:tt, $(($path:literal, $value:expr)),*) => {
             struct $name {}
 
-            impl FieldGetter for $name{
+            impl<'f> FieldGetter<'f> for $name{
 
                 fn get_from_iter(&self, _: core::slice::Iter<'_, std::string::String>) -> Option<$crate::FieldValue>{
                     unimplemented!()
@@ -511,7 +517,7 @@ mod test {
                 }
             }
 
-            impl Event for $name {
+            impl<'e> Event<'e> for $name {
 
                 fn id(&self) -> i64{
                     42

--- a/gene/src/rules/condition.rs
+++ b/gene/src/rules/condition.rs
@@ -83,12 +83,15 @@ impl FromStr for Expr {
 
 impl Expr {
     #[inline]
-    fn compute_for_event<E: Event>(
+    fn compute_for_event<E>(
         &self,
         event: &E,
         operands: &HashMap<String, Match>,
         rule_states: &HashMap<Cow<'_, str>, bool>,
-    ) -> Result<bool, Error> {
+    ) -> Result<bool, Error>
+    where
+        E: for<'e> Event<'e>,
+    {
         match self {
             Expr::AllOfThem => {
                 for m in operands.values() {
@@ -340,12 +343,15 @@ impl From<Expr> for Condition {
 }
 
 impl Condition {
-    pub(crate) fn compute_for_event<E: Event>(
+    pub(crate) fn compute_for_event<E>(
         &self,
         event: &E,
         operands: &HashMap<String, Match>,
         rules_states: &HashMap<Cow<'_, str>, bool>,
-    ) -> Result<bool, Error> {
+    ) -> Result<bool, Error>
+    where
+        E: for<'e> Event<'e>,
+    {
         self.expr.compute_for_event(event, operands, rules_states)
     }
 }


### PR DESCRIPTION
This PR get rid of string field cloning to gain around 10% scan speed. 

As a consequence some lifetime parameters needed to be introduced in Event and FieldGetter traits but this should be transparent to end users using the derive macros. For manual trait implementation this will need to be fixed.