### PR TITLE
feat: add vector and hashmap field access support

### DIFF
--- a/gene/src/compiler.rs
+++ b/gene/src/compiler.rs
@@ -52,7 +52,7 @@ impl Compiler {
     }
 
     /// Wrapper around [Compiler::load_templates_from_reader] loading a rules
-    /// from a struct implementing [AsRef<str>]
+    /// from a struct implementing [`AsRef<str>`]
     pub fn load_templates_from_str<S: AsRef<str>>(&mut self, s: S) -> Result<(), Error> {
         let c = io::Cursor::new(s.as_ref());
         self.load_templates_from_reader(c)
@@ -76,7 +76,7 @@ impl Compiler {
     }
 
     /// Wrapper around [Compiler::load_rules_from_reader] loading a rules
-    /// from a struct implementing [AsRef<str>]
+    /// from a struct implementing [`AsRef<str>`]
     pub fn load_rules_from_str<S: AsRef<str>>(&mut self, s: S) -> Result<(), Error> {
         let c = io::Cursor::new(s.as_ref());
         self.load_rules_from_reader(c)

--- a/gene/src/engine.rs
+++ b/gene/src/engine.rs
@@ -509,7 +509,7 @@ mod test {
                     unimplemented!()
                 }
 
-                fn get_from_path(&self, path: &crate::XPath) -> Option<$crate::FieldValue> {
+                fn get_from_path(&self, path: &crate::XPath) -> Option<$crate::FieldValue<'_>> {
                     match path.to_string_lossy().as_ref() {
                         $($path => Some($value.into()),)*
                         _ => None,

--- a/gene/src/engine.rs
+++ b/gene/src/engine.rs
@@ -214,7 +214,7 @@ pub enum Error {
 
 /// Structure to represent an [`Event`] scanning engine.
 /// Its role being to scan any structure implementing [`Event`] trait
-/// with all the [Rules](Rule) loaded into the engine
+/// with all the [`rules::Rule`] loaded into the engine
 ///
 /// # Example
 ///

--- a/gene/src/event.rs
+++ b/gene/src/event.rs
@@ -62,6 +62,7 @@ macro_rules! impl_for_type {
 impl_for_type!(
     Cow<'_, str>,
     Cow<'_, PathBuf>,
+    &'_ str,
     str,
     String,
     i8,

--- a/gene/src/event.rs
+++ b/gene/src/event.rs
@@ -102,21 +102,24 @@ where
     }
 }
 
-impl<'field> FieldGetter<'field> for HashMap<String, String> {
+impl<'f, T> FieldGetter<'f> for HashMap<String, T>
+where
+    T: FieldGetter<'f>,
+{
     #[inline]
     fn get_from_iter(
-        &'field self,
+        &'f self,
         mut i: core::slice::Iter<'_, std::string::String>,
-    ) -> Option<FieldValue<'field>> {
+    ) -> Option<FieldValue<'f>> {
         let k = match i.next() {
             Some(s) => s,
-            None => return Some(FieldValue::Some),
+            None => {
+                // No key to look up, return Some to indicate map existence
+                return Some(FieldValue::Some);
+            }
         };
 
-        if i.len() > 0 {
-            return None;
-        }
-        self.get(k).map(|f| f.into())
+        self.get(k)?.get_from_iter(i)
     }
 }
 

--- a/gene/src/event.rs
+++ b/gene/src/event.rs
@@ -334,4 +334,66 @@ mod test {
             .get_from_path(&path!(".numbers.first"))
             .is_none());
     }
+
+    #[test]
+    fn test_hashmap_field_getter() {
+        use std::collections::HashMap;
+
+        // Test direct HashMap implementation
+        let mut map = HashMap::new();
+        map.insert("name".to_string(), "test".to_string());
+
+        // Test accessing existing keys
+        assert_eq!(map.get_from_path(&path!(".name")), Some("test".into()));
+
+        // Test accessing non-existing keys
+        assert_eq!(map.get_from_path(&path!(".unknown")), None);
+
+        // Test that nested access returns None (more than one segment)
+        assert_eq!(map.get_from_path(&path!(".name.nested")), None);
+
+        // Test in a struct context
+        #[derive(FieldGetter)]
+        struct TestStruct {
+            data: HashMap<String, String>,
+            metadata: HashMap<String, i32>,
+        }
+
+        let mut data_map = HashMap::new();
+        data_map.insert("key1".to_string(), "value1".to_string());
+        data_map.insert("key2".to_string(), "value2".to_string());
+
+        let mut metadata_map = HashMap::new();
+        metadata_map.insert("count".to_string(), 100);
+        metadata_map.insert("size".to_string(), 200);
+
+        let test_struct = TestStruct {
+            data: data_map,
+            metadata: metadata_map,
+        };
+
+        // Test accessing hashmap fields directly
+        assert_eq!(
+            test_struct.get_from_path(&path!(".data")),
+            Some(FieldValue::Some)
+        );
+        assert_eq!(
+            test_struct.get_from_path(&path!(".metadata")),
+            Some(FieldValue::Some)
+        );
+
+        // Test accessing nested hashmap values
+        assert_eq!(
+            test_struct.get_from_path(&path!(".data.key1")),
+            Some("value1".into())
+        );
+        assert_eq!(
+            test_struct.get_from_path(&path!(".metadata.count")),
+            Some(100i32.into())
+        );
+
+        // Test accessing non-existing nested keys
+        assert_eq!(test_struct.get_from_path(&path!(".data.unknown")), None);
+        assert_eq!(test_struct.get_from_path(&path!(".metadata.missing")), None);
+    }
 }

--- a/gene/src/lib.rs
+++ b/gene/src/lib.rs
@@ -1,4 +1,5 @@
 #![deny(unused_imports)]
+#![allow(clippy::derivable_impls)]
 
 mod event;
 pub use event::{Event, FieldGetter};

--- a/gene/src/rules.rs
+++ b/gene/src/rules.rs
@@ -505,11 +505,11 @@ mod test {
 
             impl<'f> FieldGetter<'f> for $name{
 
-                fn get_from_iter(&self, _: core::slice::Iter<'_, std::string::String>) -> Option<$crate::FieldValue>{
+                fn get_from_iter(&self, _: core::slice::Iter<'_, std::string::String>) -> Option<$crate::FieldValue<'_>>{
                     unimplemented!()
                 }
 
-                fn get_from_path(&self, path: &crate::XPath) -> Option<$crate::FieldValue> {
+                fn get_from_path(&self, path: &crate::XPath) -> Option<$crate::FieldValue<'_>> {
                     match path.to_string_lossy().as_ref() {
                         $($path => Some($value.into()),)*
                         _ => None,

--- a/gene/src/rules/matcher.rs
+++ b/gene/src/rules/matcher.rs
@@ -377,6 +377,15 @@ impl DirectMatch {
 
         let fv = compat.as_ref().unwrap_or(tgt);
 
+        if let FieldValue::Vector(v) = fv {
+            for fv in v.iter() {
+                if self.match_value(fv)? {
+                    return Ok(true);
+                }
+            }
+            return Ok(false);
+        }
+
         match self.op {
             Op::Eq => cmp_values!(String, fv, ==, self.value)
                 .or({

--- a/gene/src/values.rs
+++ b/gene/src/values.rs
@@ -210,18 +210,6 @@ pub enum FieldValue<'field> {
     None,
 }
 
-impl std::fmt::Display for FieldValue<'_> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Self::String(s) => write!(f, "{s}"),
-            Self::Number(s) => write!(f, "{s}"),
-            Self::Bool(b) => write!(f, "{b}"),
-            Self::Some => write!(f, "some"),
-            Self::None => write!(f, "none"),
-        }
-    }
-}
-
 impl FieldValue<'_> {
     pub(crate) const fn type_str(&self) -> &'static str {
         match self {

--- a/gene/src/values.rs
+++ b/gene/src/values.rs
@@ -307,6 +307,12 @@ impl<'s> From<&'s str> for FieldValue<'s> {
     }
 }
 
+impl<'s> From<&&'s str> for FieldValue<'s> {
+    fn from(value: &&'s str) -> Self {
+        Self::String(Cow::Borrowed(value))
+    }
+}
+
 impl From<String> for FieldValue<'_> {
     fn from(value: String) -> Self {
         Self::String(Cow::from(value))

--- a/gene/src/values.rs
+++ b/gene/src/values.rs
@@ -327,7 +327,7 @@ impl<'s> From<&'s String> for FieldValue<'s> {
 
 impl From<PathBuf> for FieldValue<'_> {
     fn from(value: PathBuf) -> Self {
-        Self::String(value.to_string_lossy().to_string().into())
+        value.to_string_lossy().to_string().into()
     }
 }
 

--- a/gene/src/values.rs
+++ b/gene/src/values.rs
@@ -199,7 +199,7 @@ impl Number {
 }
 
 /// A FieldValue is an enum representing the different values
-/// a field from a structure can have. Many convertions
+/// a field from a structure can have. Many conversions
 /// from base and common types are implemented.
 #[derive(Debug, Clone, PartialEq)]
 pub enum FieldValue<'field> {


### PR DESCRIPTION
This PR improves enhance FieldGetter/FieldValue support for container types.

**Motivation**
- Extend FieldGetter/FieldValue support for Vec<T> and HashMap types

**Changes**
- **FieldGetter**: Added Vec<T> implementation and comprehensive tests
- **FieldValue**: Added HashMap<String, T> tests and macro-based conversions
- Minor changes in documentation and clippy linting