### PR TITLE
feat: introduce FieldNameIterator for field path traversal

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ cargo add gene_derive
 ## Quickstart
 
 ```rust
-use gene::{Compiler, Engine, Event, FieldGetter, FieldValue};
+use gene::{Compiler, Engine, Event, FieldGetter, FieldValue, FieldNameIterator};
 use gene_derive::{Event, FieldGetter};
 
 // 1. Define your event structure

--- a/derive/src/lib.rs
+++ b/derive/src/lib.rs
@@ -213,7 +213,7 @@ impl EventDerive {
 ///
 /// ```rust
 /// use gene_derive::{Event, FieldGetter};
-/// use gene::{Event,FieldGetter,FieldValue};
+/// use gene::{Event, FieldGetter, FieldValue, FieldNameIterator};
 /// use std::borrow::Cow;
 ///
 /// #[derive(Event, FieldGetter)]
@@ -287,7 +287,7 @@ impl FieldGetterDerive {
             span =>
             #(#fields)|* => {
                 #[allow(clippy::redundant_closure_call)]
-                |x: &#flt dyn FieldGetter<#flt>, i: core::slice::Iter<'_, std::string::String>| -> Option<FieldValue<#flt>> {
+                |x: &#flt dyn FieldGetter<#flt>, i: FieldNameIterator| -> Option<FieldValue<#flt>> {
                     x.get_from_iter(i)
                 }(&self.#field_name, i)
             }});
@@ -358,14 +358,14 @@ impl FieldGetterDerive {
         let expand = quote! {
             impl #trait_generics FieldGetter<#flt> for #struct_name #generics #generic_trait_bound{
                 #[inline(always)]
-                fn get_from_iter(&#flt self, mut i: core::slice::Iter<'_, std::string::String>) -> Option<FieldValue<#flt>> {
+                fn get_from_iter(&#flt self, mut i: FieldNameIterator) -> Option<FieldValue<#flt>> {
 
-                    let field = match i.next() {
+                    let field = match i.next_field_name() {
                         Some(s) => s,
                         None => return Some(FieldValue::Some),
                     };
 
-                    match field.as_str() {
+                    match field {
                         #(#arms)*
                         _ => None,
                     }

--- a/gene/benches/engine_benchmark.rs
+++ b/gene/benches/engine_benchmark.rs
@@ -5,7 +5,7 @@ use std::{
 };
 
 use criterion::{criterion_group, criterion_main, Criterion, Throughput};
-use gene::{Compiler, Engine, Event, FieldGetter, FieldValue, Rule};
+use gene::{Compiler, Engine, Event, FieldGetter, FieldValue, Rule, FieldNameIterator};
 use gene_derive::{Event, FieldGetter};
 use libflate::gzip;
 use serde::{Deserialize, Deserializer};

--- a/gene/src/engine.rs
+++ b/gene/src/engine.rs
@@ -491,7 +491,7 @@ struct RuleCacheEntry {
 ///
 /// ```
 /// use gene_derive::{Event, FieldGetter};
-/// use gene::{Compiler, Engine, Event,FieldGetter,FieldValue};
+/// use gene::{Compiler, Engine, Event, FieldGetter, FieldValue, FieldNameIterator};
 /// use std::borrow::Cow;
 ///
 /// #[derive(FieldGetter)]
@@ -786,6 +786,7 @@ impl Engine {
 #[cfg(test)]
 mod test {
     use super::*;
+    use crate::{FieldGetter, FieldNameIterator};
 
     macro_rules! fake_event {
         ($name:tt, id=$id:literal, source=$source:literal, $(($path:literal, $value:expr)),*) => {
@@ -793,7 +794,7 @@ mod test {
 
             impl<'f> FieldGetter<'f> for $name{
 
-                fn get_from_iter(&'f self, _: core::slice::Iter<'_, std::string::String>) -> Option<$crate::FieldValue<'f>>{
+                fn get_from_iter(&'f self, _: FieldNameIterator<'_>) -> Option<$crate::FieldValue<'f>>{
                     unimplemented!()
                 }
 

--- a/gene/src/engine.rs
+++ b/gene/src/engine.rs
@@ -8,7 +8,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     compiler,
     rules::{self, bound_severity, CompiledRule, Decision},
-    Compiler, Event, FieldValue,
+    Compiler, Event, FieldValue, FieldNameIterator
 };
 
 use crate::FieldGetter;

--- a/gene/src/event.rs
+++ b/gene/src/event.rs
@@ -7,6 +7,115 @@ use std::{
 
 use crate::{FieldValue, XPath};
 
+/// An iterator over field names in an [`XPath`]-like path.
+///
+/// This iterator is used to traverse field names in structured data paths,
+/// such as `.parent.child.field` in jq notation. It provides methods to
+/// access the current field name and advance to the next one.
+///
+/// The iterator can be created from an [`XPath`] using the [`From`] trait,
+/// or directly from a slice of field names.
+///
+/// # Examples
+///
+/// ```
+/// use gene::{FieldNameIterator, XPath};
+///
+/// // From XPath
+/// let path = XPath::parse(".parent.child.field").unwrap();
+/// let mut iter = FieldNameIterator::from(&path);
+///
+/// assert_eq!(iter.next_field_name(), Some("parent"));
+/// assert_eq!(iter.next_field_name(), Some("child"));
+/// assert_eq!(iter.next_field_name(), Some("field"));
+/// assert_eq!(iter.next_field_name(), None);
+///
+/// // From field names directly
+/// let field_names = vec!["parent".to_string(), "child".to_string(), "field".to_string()];
+/// let mut iter = FieldNameIterator::from(field_names.as_slice());
+///
+/// assert_eq!(iter.next_field_name(), Some("parent"));
+/// assert_eq!(iter.next_field_name(), Some("child"));
+/// assert_eq!(iter.next_field_name(), Some("field"));
+/// assert_eq!(iter.next_field_name(), None);
+/// ```
+pub struct FieldNameIterator<'f> {
+    i: Option<usize>,
+    field_names: &'f [String],
+}
+
+impl<'f> From<&'f [String]> for FieldNameIterator<'f> {
+    fn from(value: &'f [String]) -> Self {
+        Self {
+            i: None,
+            field_names: value,
+        }
+    }
+}
+
+impl<'f> From<&'f XPath> for FieldNameIterator<'f> {
+    fn from(value: &'f XPath) -> Self {
+        value.segments().into()
+    }
+}
+
+impl<'f> FieldNameIterator<'f> {
+    /// Advances the iterator and returns the next field name.
+    ///
+    /// This method moves the iterator to the next position and returns the field name
+    /// at that position. On the first call, it returns the first field name.
+    /// When the iterator reaches the end, it returns `None`.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gene::FieldNameIterator;
+    ///
+    /// let field_names = vec!["field1".to_string(), "field2".to_string()];
+    /// let mut iter = FieldNameIterator::from(field_names.as_slice());
+    ///
+    /// assert_eq!(iter.next_field_name(), Some("field1"));
+    /// assert_eq!(iter.next_field_name(), Some("field2"));
+    /// assert_eq!(iter.next_field_name(), None);
+    /// ```
+    #[inline]
+    pub fn next_field_name(&mut self) -> Option<&str> {
+        match self.i.as_mut() {
+            Some(i) => {
+                *i = i.checked_add(1)?;
+                self.field_names.get(*i).map(|s| s.as_ref())
+            }
+            None => {
+                self.i = Some(0);
+                self.field_names.first().map(|s| s.as_ref())
+            }
+        }
+    }
+
+    /// Checks if the iterator is at the last field name.
+    ///
+    /// Returns `true` if the current position is at the last field name in the path,
+    /// indicating that this is a terminal field access. Returns `false` otherwise.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use gene::FieldNameIterator;
+    ///
+    /// let field_names = vec!["field1".to_string(), "field2".to_string()];
+    /// let mut iter = FieldNameIterator::from(field_names.as_slice());
+    ///
+    /// assert_eq!(iter.next_field_name(), Some("field1"));
+    /// assert!(!iter.is_terminal()); // At start, not terminal
+    /// assert_eq!(iter.next_field_name(), Some("field2"));
+    /// assert!(iter.is_terminal()); // After advancing once, at last field
+    /// ```
+    #[inline(always)]
+    pub fn is_terminal(&self) -> bool {
+        self.i.unwrap_or_default() == self.field_names.len() - 1
+    }
+}
+
 /// Trait representing a log event that can be scanned by the engine.
 ///
 /// Events provide access to their unique identifier, source, and field values
@@ -16,7 +125,7 @@ use crate::{FieldValue, XPath};
 /// # Examples
 ///
 /// ```
-/// use gene::{FieldValue, Event, FieldGetter};
+/// use gene::{FieldValue, Event, FieldGetter, FieldNameIterator};
 /// use gene_derive::{Event, FieldGetter};
 /// use std::borrow::Cow;
 ///
@@ -54,7 +163,7 @@ pub trait Event<'event>: FieldGetter<'event> {
 /// # Examples
 ///
 /// ```
-/// use gene::{FieldGetter, FieldValue};
+/// use gene::{FieldGetter, FieldValue, FieldNameIterator};
 /// use std::net::IpAddr;
 ///
 /// struct NetworkEvent {
@@ -66,9 +175,9 @@ pub trait Event<'event>: FieldGetter<'event> {
 /// impl<'f> FieldGetter<'f> for NetworkEvent {
 ///     fn get_from_iter(
 ///         &'f self,
-///         mut i: core::slice::Iter<'_, std::string::String>,
+///         mut i: FieldNameIterator,
 ///     ) -> Option<FieldValue<'f>> {
-///         match i.next().map(|s| s.as_str()) {
+///         match i.next_field_name() {
 ///             Some("source_ip") => Some(self.source_ip.to_string().into()),
 ///             Some("destination_ip") => Some(self.destination_ip.to_string().into()),
 ///             Some("port") => Some(self.port.into()),
@@ -109,7 +218,7 @@ pub trait FieldGetter<'field> {
     /// override [`Self::get_from_iter`] instead of overriding this method.
     #[inline]
     fn get_from_path(&'field self, path: &XPath) -> Option<FieldValue<'field>> {
-        self.get_from_iter(path.iter_segments())
+        self.get_from_iter(FieldNameIterator::from(path))
     }
 
     /// Gets a field value using an iterator of path segments.
@@ -126,10 +235,7 @@ pub trait FieldGetter<'field> {
     ///
     /// * `Some(FieldValue)` if the field exists and can be accessed
     /// * `None` if the field does not exist or cannot be accessed
-    fn get_from_iter(
-        &'field self,
-        i: core::slice::Iter<'_, std::string::String>,
-    ) -> Option<FieldValue<'field>>;
+    fn get_from_iter(&'field self, i: FieldNameIterator<'_>) -> Option<FieldValue<'field>>;
 }
 
 macro_rules! impl_with_getter {
@@ -137,8 +243,8 @@ macro_rules! impl_with_getter {
         $(
             impl<'f> FieldGetter<'f> for $type {
                 #[inline]
-                fn get_from_iter(&'f self, i: core::slice::Iter<'_, std::string::String>) -> Option<FieldValue<'f>> {
-                    if i.len() > 0 {
+                fn get_from_iter(&'f self, i: FieldNameIterator<'_>) -> Option<FieldValue<'f>> {
+                    if !i.is_terminal() {
                         return None;
                     }
                     Some(self.$getter().into())
@@ -153,8 +259,8 @@ macro_rules! impl_for_type {
         $(
             impl<'f> FieldGetter<'f>  for $type {
                 #[inline]
-                fn get_from_iter(&'f self, i: core::slice::Iter<'_, std::string::String>) -> Option<FieldValue<'f>> {
-                    if i.len() > 0 {
+                fn get_from_iter(&'f self, i: FieldNameIterator<'_>) -> Option<FieldValue<'f>> {
+                    if !i.is_terminal() {
                         return None;
                     }
                     Some(self.into())
@@ -196,10 +302,7 @@ where
     T: FieldGetter<'field>,
 {
     #[inline]
-    fn get_from_iter(
-        &'field self,
-        i: core::slice::Iter<'_, std::string::String>,
-    ) -> Option<FieldValue<'field>> {
+    fn get_from_iter(&'field self, i: FieldNameIterator<'_>) -> Option<FieldValue<'field>> {
         match self {
             Some(v) => v.get_from_iter(i),
             None => Some(FieldValue::None),
@@ -212,11 +315,8 @@ where
     T: FieldGetter<'f>,
 {
     #[inline]
-    fn get_from_iter(
-        &'f self,
-        mut i: core::slice::Iter<'_, std::string::String>,
-    ) -> Option<FieldValue<'f>> {
-        let k = match i.next() {
+    fn get_from_iter(&'f self, mut i: FieldNameIterator<'_>) -> Option<FieldValue<'f>> {
+        let k = match i.next_field_name() {
             Some(s) => s,
             None => {
                 // No key to look up, return Some to indicate map existence
@@ -238,9 +338,9 @@ macro_rules! impl_field_getter_for_vec {
                 #[inline]
                 fn get_from_iter(
                     &'f self,
-                    i: core::slice::Iter<'_, std::string::String>,
+                    i: FieldNameIterator<'_>,
                 ) -> Option<FieldValue<'f>> {
-                    if i.len() > 0 {
+                    if !i.is_terminal(){
                         return None;
                     }
 

--- a/gene/src/lib.rs
+++ b/gene/src/lib.rs
@@ -44,7 +44,7 @@
 //! ## Quickstart
 //!
 //! ```
-//! use gene::{Compiler, Engine, Event, FieldGetter, FieldValue};
+//! use gene::{Compiler, Engine, Event, FieldGetter, FieldValue, FieldNameIterator};
 //! use gene_derive::{Event, FieldGetter};
 //!
 //! // 1. Define your event structure
@@ -177,7 +177,7 @@
 //! Gene is licensed under the **GPL-3.0** - see the `LICENSE` file for details.
 
 mod event;
-pub use event::{Event, FieldGetter};
+pub use event::{Event, FieldGetter, FieldNameIterator};
 
 pub mod rules;
 pub use rules::Rule;

--- a/gene/src/paths.rs
+++ b/gene/src/paths.rs
@@ -18,7 +18,7 @@ pub enum PathError {
 ///
 /// ```rust
 /// use ::gene_derive::FieldGetter;
-/// use ::gene::{XPath, FieldGetter, FieldValue};
+/// use ::gene::{XPath, FieldGetter, FieldValue, FieldNameIterator};
 ///
 /// #[derive(FieldGetter)]
 /// struct LogData

--- a/gene/src/rules.rs
+++ b/gene/src/rules.rs
@@ -718,7 +718,7 @@ mod test {
     use std::path::PathBuf;
 
     use super::*;
-    use crate::{Event, FieldGetter, FieldValue};
+    use crate::{Event, FieldGetter, FieldValue, FieldNameIterator};
     use gene_derive::{Event, FieldGetter};
 
     macro_rules! def_event {
@@ -741,7 +741,7 @@ mod test {
 
             impl<'f> FieldGetter<'f> for $name{
 
-                fn get_from_iter(&self, _: core::slice::Iter<'_, std::string::String>) -> Option<$crate::FieldValue<'_>>{
+                fn get_from_iter(&self, _: FieldNameIterator<'_>) -> Option<$crate::FieldValue<'_>>{
                     unimplemented!()
                 }
 


### PR DESCRIPTION
**Summary**
This PR introduces `FieldNameIterator`, a dedicated iterator type for traversing field names in XPath-like paths (e.g., `.parent.child.field`). It replaces the previous use of `core::slice::Iter` throughout the codebase, improving API clarity.

**Motivation**
The previous implementation used `core::slice::Iter<'_, String>` directly in the `FieldGetter` trait, which:
- Exposed internal implementation details
- Lacked domain-specific methods for field traversal
- Made the API less intuitive for users implementing custom `FieldGetter` types

**Changes**
- Added `FieldNameIterator<'f>` struct with proper documentation and examples
- Implemented `From<&[String]>` and `From<&XPath>` traits for easy creation
- Added domain-specific methods: `next_field_name()`, `is_terminal()`
- Updated `FieldGetter::get_from_iter()` signature to use `FieldNameIterator`
- Refactored all implementations in `gene` and `gene_derive` crates
- Updated examples and documentation throughout the codebase

**Breaking Changes**
- `FieldGetter::get_from_iter()` method signature changed from `core::slice::Iter<'_, String>` to `FieldNameIterator<'_>`
- Users implementing custom `FieldGetter` traits will need to update their implementations
